### PR TITLE
Inserting data into any type

### DIFF
--- a/dot.go
+++ b/dot.go
@@ -119,6 +119,12 @@ func (d *Dot) insert(innerObj reflect.Value, previousPath string, parts []string
 			if innerObj.Kind() == reflect.Chan {
 				return d.inChannel(innerObj, currentPath, remainingParts)
 			}
+		case reflect.Interface:
+			return fmt.Errorf(
+				"the type in %s is interface{} and it is impossible to further predict the path",
+				previousPath,
+			)
+
 		default:
 			// If it is logical to already insert a value in the specified path,
 			// but the path has not yet ended, it means that the path is specified incorrectly
@@ -140,7 +146,7 @@ func set(innerObj reflect.Value, currentPath string, content any, source Scenari
 	value := reflect.ValueOf(content)
 
 	// Checking for type matching
-	if innerObj.Type() != value.Type() {
+	if innerObj.Type() != value.Type() && innerObj.Kind() != reflect.Interface {
 		return fmt.Errorf(
 			errMsg[source], innerObj.Type(), value.Type(), currentPath,
 		)


### PR DESCRIPTION
@NV4RE described the unusual behaviour of the dot package: https://github.com/mowshon/dot/issues/2

The problem is that if the data insertion path is of type `interface{}` then **dot** won't know how to determine the further path.

```golang
package main

import (
	"fmt"

	"github.com/mowshon/dot"
)

type MyShopStock struct {
	Shelf     map[string]any
	Werehouse map[string]any
}

type Product struct {
	Price float64
	Name  string
	Qty   uint
}

func main() {
	data := &MyShopStock{
		Shelf: map[string]any{
			"Apple":  Product{Price: 1.99, Name: "apple", Qty: 10},
			"Banana": Product{Price: 0.99, Name: "banana", Qty: 5},
			"Orange": Product{},
		},
	}

	obj, err := dot.New(data)

	err = obj.Insert("Shelf.Orange.Qty", 5)
	fmt.Println(err)
}
```

After this PR, this code will return an error:

```
the type in Shelf.Orange is interface{} and it is impossible to further predict the path
```

## Possible solution

If the final destination path is of type `any`, the value will be inserted without any problems.

```golang
err = obj.Insert("Shelf.Orange", Product{
	Qty: 5,
})
```